### PR TITLE
Prettier fixed on ItemPreview component

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,12 +36,9 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-        onError={({ currentTarget }) =>
-          (currentTarget.src = "/placeholder.png")
-        }
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -39,6 +39,9 @@ const ItemPreview = (props) => {
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
+        onError={({ currentTarget }) =>
+          (currentTarget.src = "/placeholder.png")
+        }
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">


### PR DESCRIPTION
# Description

Present default product image in case product is created without a defined image.
In this case, a broken image has been presented to the user in the product catalog.

Fixes # (if relevant)

This fixes bug #3 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Create a product without an image. You can use the seed data to create such products. Make sure each product with a defined image, presents the default image as presented in the attach screenshot:
![Screen Shot 2022-02-10 at 20 12 19](https://user-images.githubusercontent.com/1535780/153472233-dc2a48e6-629e-4d53-864f-cac4681b88c8.png)

